### PR TITLE
Un-require message property; enable default AssertionError message in catch mode

### DIFF
--- a/batch-assert.js
+++ b/batch-assert.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+
+let MissingTestError = new Error("Test was not defined in test object");
+
+let assertTest = function ({ test, result, message }, index) {
+  if (test === undefined) {
+    throw MissingTestError;
+  }
+  if (message) {
+    assert.deepStrictEqual(test, result, message);
+  } else {
+    assert.deepStrictEqual(test, result);
+  };
+  console.log(`Test ${index} passed.`);
+}
+
+let testAll = function (batch, throwOnFail = true) {
+  if (throwOnFail) {
+    batch.forEach((test, index) => { assertTest(test, index) });
+  } else {
+    batch.forEach((test, index) => {
+      try {
+        assertTest(test, index);
+      } catch (AssertionError) {
+        let defaultMessage = `${AssertionError.actual} ${AssertionError.operator} ${AssertionError.expected}`
+        console.log(`Test ${index} FAILED: ${(test.message ? test.message : defaultMessage)}`)
+      }
+    });
+  };
+};
+
+module.exports.testAll = testAll;

--- a/batchAssert.js
+++ b/batchAssert.js
@@ -1,13 +1,16 @@
 const assert = require('assert');
 
-let MissingArgumentError = new Error("One or more arguments missing from test object");
+let MissingTestError = new Error("Test was not defined in test object");
 
 let assertTest = function ({ test, result, message }, index) {
-  if (test === undefined ||
-    message === undefined) {
-    throw MissingArgumentError;
+  if (test === undefined) {
+    throw MissingTestError;
   }
-  assert.deepStrictEqual(test, result, message);
+  if (message) {
+    assert.deepStrictEqual(test, result, message);
+  } else {
+    assert.deepStrictEqual(test, result);
+  };
   console.log(`Test ${index} passed.`);
 }
 
@@ -19,7 +22,8 @@ let testAll = function (batch, throwOnFail = true) {
       try {
         assertTest(test, index);
       } catch (AssertionError) {
-        console.log(`Test ${index} FAILED: ${test.message}`)
+        let defaultMessage = `${AssertionError.actual} ${AssertionError.operator} ${AssertionError.expected}`
+        console.log(`Test ${index} FAILED: ${(test.message ? test.message : defaultMessage)}`)
       }
     });
   };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "batchassert",
+  "version": "1.0.0",
+  "description": "Assert testing module for explicit pass/fail console output, with optional AssertException bypass",
+  "main": "batchAssert.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BGamber/batchAssert.git"
+  },
+  "keywords": [
+    "assert",
+    "batch",
+    "npm",
+    "module"
+  ],
+  "author": "Ben Gamber",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/BGamber/batchAssert/issues"
+  },
+  "homepage": "https://github.com/BGamber/batchAssert#readme"
+}


### PR DESCRIPTION
Default AssertionError messages can still provide some context, so requiring user to provide a message property in the test objects has been removed, and "catch mode" (throwOnFail = false) will now print the default AssertionError message if one has not been provided.

Custom error is now called MissingTestError, as the only required property now is the test itself.